### PR TITLE
Use Nix flake for devShell, create Nix package

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
+fi
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.direnv/
+result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2024 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2020-2024 Eelco Dolstra and the flake-compat contributors
+#
+# SPDX-License-Identifier: MIT
+# This file originates from:
+# https://github.com/nix-community/flake-compat
+# This file provides backward compatibility to nix < 2.4 clients
+{system ? builtins.currentSystem}: let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
+
+  flake-compat = fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+
+  flake = import flake-compat {
+    inherit system;
+    src = ./.;
+  };
+in
+  flake.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,111 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1717312683,
+        "narHash": "sha256-FrlieJH50AuvagamEvWMIE6D2OAnERuDboFDYAED/dE=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "38fd3954cf65ce6faf3d0d45cd26059e059f07ea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-root": {
+      "locked": {
+        "lastModified": 1713493429,
+        "narHash": "sha256-ztz8JQkI08tjKnsTpfLqzWoKFQF4JGu2LRz8bkdnYUk=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "bc748b93b86ee76e2032eecda33440ceb2532fcd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720031269,
+        "narHash": "sha256-rwz8NJZV+387rnWpTYcXaRNvzUSnnF9aHONoJIYmiUQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1720436211,
+        "narHash": "sha256-/cKXod0oGLl+vH4bKBZnTV3qxrw4jgOLnyQ8KXey5J8=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "6fc8bded78715cdd43a3278a14ded226eb3a239e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  description = "Ghaf Control Panel Flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-compat.url = "github:nix-community/flake-compat";
+
+    # Modularity
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-root.url = "github:srid/flake-root";
+
+    # Formatting
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs @ {flake-parts, ...}:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      imports = [
+        ./nix/treefmt.nix
+        ./nix/devshell.nix
+      ];
+      systems = ["x86_64-linux" "aarch64-linux" "riscv64-linux"];
+      perSystem = {pkgs, ...}: {
+        packages.default = pkgs.callPackage ./nix {};
+      };
+    };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,50 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  cargo,
+  glib,
+  gtk4,
+  lib,
+  libadwaita,
+  librsvg,
+  pkg-config,
+  protobuf,
+  protoc-gen-tonic,
+  rustPlatform,
+  rustc,
+  version ? "git",
+}:
+rustPlatform.buildRustPackage {
+  pname = "ghaf-ctrl-panel";
+  inherit version;
+  meta = with lib; {
+    description = "Ghaf Control Panel";
+    license = licenses.asl20;
+    mainProgram = "ctrl-panel";
+  };
+
+  buildInputs = [
+    gtk4
+    glib
+    libadwaita
+  ];
+
+  nativeBuildInputs = [
+    gtk4
+    glib
+    rustPlatform.cargoSetupHook
+    rustc
+    cargo
+    pkg-config
+    protoc-gen-tonic
+    protobuf
+  ];
+
+  gappsWrapperArgs = ''
+    --prefix XDG_DATA_DIRS : "${librsvg}/share"
+  '';
+
+  cargoLock.lockFile = ../Cargo.lock;
+
+  src = ./..;
+}

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,0 +1,22 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  perSystem = {pkgs, ...}: {
+    devShells.default = pkgs.mkShell {
+      packages = [
+        pkgs.bashInteractive
+
+        pkgs.glib
+        pkgs.gtk4
+        pkgs.libadwaita
+        pkgs.pkg-config
+        pkgs.gcc
+        pkgs.rustc
+        pkgs.cargo
+        pkgs.protoc-gen-tonic
+        pkgs.protobuf
+      ];
+      PKG_CONFIG_PATH = "${pkgs.glib.dev}/lib/pkgconfig:${pkgs.gtk4.dev}/lib/pkgconfig";
+    };
+  };
+}

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -1,0 +1,27 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{inputs, ...}: {
+  imports = with inputs; [
+    flake-root.flakeModule
+    treefmt-nix.flakeModule
+  ];
+  perSystem = {
+    config,
+    pkgs,
+    ...
+  }: {
+    treefmt.config = {
+      package = pkgs.treefmt;
+      inherit (config.flake-root) projectRootFile;
+
+      programs = {
+        alejandra.enable = true;
+        deadnix.enable = true;
+        statix.enable = true;
+        rustfmt.enable = true;
+      };
+    };
+
+    formatter = config.treefmt.build.wrapper;
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,6 @@
-{ pkgs ? import <nixpkgs> {} }:
-
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{pkgs ? import <nixpkgs> {}}:
 pkgs.mkShell {
   buildInputs = [
     pkgs.glib
@@ -10,6 +11,7 @@ pkgs.mkShell {
     pkgs.rustc
     pkgs.cargo
     pkgs.protoc-gen-tonic
+    pkgs.protobuf
   ];
 
   shellHook = ''


### PR DESCRIPTION
- Use Nix flake for devShell.
  - Support nix-direnv for automatically loading dependencies.
- Add treefmt-nix with `nix fmt`.
  - Also formats Rust code using `rustfmt`.
- Create Nix package for the control panel.
  - Now able to build with `nix build`, and run with `nix run`.
  - Builds faster when using remote builders.