### PR TITLE
Audio Fix and logging improvement

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -320,7 +320,7 @@ impl ControlPanelGuiApplication {
     }
 
     pub fn perform_setting_action(&self, action: SettingsAction) {
-        eprintln!("Performing settings action... {action:?}");
+        debug!("Performing settings action... {action:?}");
         match action {
             SettingsAction::RegionNLanguage { locale, timezone } => {
                 self.imp().set_locale_timezone(locale, timezone);

--- a/src/audio_settings.rs
+++ b/src/audio_settings.rs
@@ -279,6 +279,12 @@ impl AudioSettings {
     }
 
     pub fn set_audio_devices(&self, devices: impl IsA<ListModel>) {
+        /* Temporarily freeze property notifications to prevent signal handlers
+        from being triggered during audio device initialization for speaker and mic.
+        The guards will automatically thaw notifications when they go out of scope. */
+        let _speaker_guard = self.imp().speaker_select().freeze_notify();
+        let _mic_guard = self.imp().mic_select().freeze_notify();
+
         //setup factory
         self.setup_factory(AudioDeviceUserType::Mic);
         self.setup_factory(AudioDeviceUserType::Speaker);

--- a/src/typed_list_store.rs
+++ b/src/typed_list_store.rs
@@ -87,6 +87,14 @@ impl<T: IsA<Object>> From<DropDown> for TypedDropDown<T> {
     }
 }
 
+impl<T: IsA<Object>> Deref for TypedDropDown<T> {
+    type Target = DropDown;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 pub trait TypedSelectionWrapperExt<T: IsA<Object>> {
     fn selected_obj(&self) -> Option<T>;
 }


### PR DESCRIPTION
PR has 2 fixes:
1. **audio: freeze property notifications during device initialization**
    
    -  Added `freeze_notify()` guards for `speaker_select` and `mic_select` in  `set_audio_devices` to temporarily suppress property change signals.
      This prevents unintended signal handler invocations while audio devices are being initialized. Notifications are automatically thawed when the guards go out of scope.
    
    -  Implemented `Deref` for `TypedDropDown<T>` to allow access to the underlying `DropDown`.

2. **logging: replace eprintln! with debug!**

**Fixes:** https://jira.tii.ae/browse/SSRCSP-6648 